### PR TITLE
can skip ssl validation

### DIFF
--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: cf-deploy
-version: 0.1.0
+version: 0.2.0
 description: Deploy application to Cloud Foundry via `cf push`
 keywords:
   - pivotal

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -29,3 +29,6 @@ properties:
   docker_image:
     type: string
     required: false
+  skip-ssl-validation:
+    type: string
+    required: false


### PR DESCRIPTION
the skip-ssl-validation parameter instructs the cf cli to not validate ssl certificates. 
